### PR TITLE
add handling of lightweight tags

### DIFF
--- a/lib/src/git_dir.dart
+++ b/lib/src/git_dir.dart
@@ -68,7 +68,11 @@ class GitDir {
 
     for (var ref in refs) {
       final pr = await runCommand(['cat-file', '-p', ref.sha]);
-      yield Tag.parseCatFile(pr.stdout as String);
+      yield Tag.parseCatFile(
+        pr.stdout as String,
+        ref.sha,
+        ref.reference.substring(10),
+      );
     }
   }
 

--- a/lib/src/tag.dart
+++ b/lib/src/tag.dart
@@ -14,7 +14,7 @@ class Tag {
     requireArgumentNotNullOrEmpty(tagger, 'tagger');
   }
 
-  static Tag parseCatFile(String content) {
+  static Tag parseCatFile(String content, String tagSha, String tagName) {
     final headers = <String, List<String>>{};
 
     final slr = StringLineReader(content);
@@ -32,10 +32,24 @@ class Tag {
       lastLine = slr.readNextLine()!;
     }
 
-    final objectSha = headers['object']!.single;
-    final type = headers['type']!.single;
-    final tag = headers['tag']!.single;
-    final tagger = headers['tagger']!.single;
+    String objectSha;
+    String type;
+    String tag;
+    String tagger;
+
+    if (headers['object'] != null) {
+      // Annotated Tag
+      objectSha = headers['object']!.single;
+      type = headers['type']!.single;
+      tag = headers['tag']!.single;
+      tagger = headers['tagger']!.single;
+    } else {
+      // Lightweight Tag
+      objectSha = tagSha;
+      type = 'lightweight';
+      tag = tagName;
+      tagger = headers['author']!.single;
+    }
 
     return Tag._internal(objectSha, type, tag, tagger);
   }


### PR DESCRIPTION
The existing `parseCatFile` function was unable to handle "lightweight" git tags, and this incompatibility is evident in the naming of `Tag`'s member variables. This PR adds handling of lightweight tags, but does not rename any `Tag` members, so you could end up with lightweight tags masquerading as annotated tags. Regardless, these fixes work for my application and I imagine they may do the same for others.